### PR TITLE
Fix eval.py script

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ The training script will save a checkpoint in the `log` directory after each 100
 ## Evaluate
 In order to try our model, we included a snapshot of our trained model (in the `log` directory). That can be used as follow:
 
-`python3 eval.py <input_img_path> <trimap_img_path> <output_img_path> --checkpoint -1`
+`python3 eval.py <input_img_path> <output_img_path> --checkpoint -1`

--- a/eval.py
+++ b/eval.py
@@ -68,8 +68,6 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Evalutate image")
     parser.add_argument("input", type=str,
         help="Path to a file containing input image")
-    parser.add_argument("object", type=str,
-        help="Path to a file containing trimap image")
     parser.add_argument("output", type=str,
         help="Path to the output file")
     parser.add_argument('--checkpoint', type=int, default=None,
@@ -116,7 +114,7 @@ def main(args):
     input_filename = args.input
     image = load_image(input_filename)
     print(image.shape)
-    trimap = generate_trimap(args.object)
+    trimap = generate_trimap(input_filename)
 
     image = np.array(image)
     trimap = np.array(trimap)[..., np.newaxis]


### PR DESCRIPTION
Since, we are already generating trimap in eval.py itself. Then, their is no need to provide trimap image as input.

Signed-off-by: Griffin98 <griffin98@protonmail.com>